### PR TITLE
Fixes typo

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -35,7 +35,7 @@ alias code='cd ~/Documents/code'
 # ---GIT---
 alias g='git'
 alias gs='git status -s'
-alias glg='git lg'
+alias glg='git log'
 alias ga='git add'
 alias gc='git commit'
 alias amend='git commit --amend'


### PR DESCRIPTION
As there is no command `git lg`, I assume it's a typo and you actually meant `git log`?